### PR TITLE
added algorithm 1 and tracked diffs between papers

### DIFF
--- a/docs/paper_vs_code_gap.md
+++ b/docs/paper_vs_code_gap.md
@@ -1,0 +1,104 @@
+# Paper vs. Code: D4RT implementation gap analysis
+
+This document compares the **D4RT paper** (`docs/D4RT_paper.pdf`, "Efficiently
+Reconstructing Dynamic Scenes One D4RT at a Time", Google DeepMind) against this
+repository's **OpenD4RT** code.
+
+> **Context.** OpenD4RT is an *unofficial, from-scratch re-implementation*. The
+> original D4RT weights and code were never released, and the paper does not
+> specify every architectural detail (the SRT-style decoder internals, exact
+> attention/position-embedding scheme, and data pipeline are described only at a
+> high level). Where the paper is silent, this repo makes its own engineering
+> choices. "Consistent with the paper" below therefore means *consistent with
+> what the paper actually states*, not bit-for-bit identical to the unreleased
+> original.
+
+Legend: ✅ implemented & faithful · ⚠️ implemented but a re-implementer's choice
+where the paper is silent · ❌ missing / stubbed / diverges.
+
+---
+
+## ✅ Faithful to the paper
+
+| Paper element | Code location |
+| --- | --- |
+| Encode video once → frozen *Global Scene Representation* `F`; decoder re-uses it for all queries | `src/model/d4rt.py:250-284` |
+| Independent query interface `q=(u,v,t_src,t_tgt,t_cam) → P∈ℝ³` | `src/model/query_embedding.py`, `infer_track_3d.py` |
+| ViT-g encoder: hidden 1408, 40 layers, patch `2×16×16`, interleaved local-framewise + global attention | `src/model/encoder.py:96-99,133-147`; `configs/model_effective.yaml:13-25` |
+| VideoMAE2 pretrained init (key remap: `qkv→in_proj`, `q_bias`/`v_bias`→`in_proj_bias` w/ zero `k_bias`) | `src/model/d4rt.py:286-364` |
+| Aspect-ratio token (resize-to-square + W/H token) | `src/model/d4rt.py:202-211`; `src/model/encoder.py:144` |
+| 8-layer cross-attention decoder, **no query self-attention** ("queries do not interact") | `src/model/decoder.py` |
+| Query embedding: Fourier(u,v) + learned discrete time embeddings + 9×9 local RGB patch | `src/model/query_embedding.py:10-39,59-71,80-118` |
+| 13-dim output head: xyz(3)+uv(2)+vis(1)+disp(3)+normal(3)+conf(1) | `src/model/heads.py` |
+| Loss: L1 xyz w/ `sign·log1p` + mean-depth normalize; L1 uv; BCE vis; L1 disp; cosine normal; `−log(c)` confidence penalty | `src/losses/d4rt_loss.py` |
+| Training recipe: AdamW, wd 0.03, warmup→cosine, grad-clip L2=10, 20% hard queries near Sobel depth/motion boundaries, `P(t_tgt=t_cam)=0.4` | `src/engine/trainer.py:241-259,965-971`; `configs/train_effective.yaml:128-201` |
+| 9-dataset training mixture (PointOdyssey, Dynamic Replica, Kubric, TartanAir, VKITTI2, ScanNet, BlendedMVS, CO3D, MVS-Synth) | `src/data/*_raw_dataset.py` (all 9 present) |
+| Camera extrinsics via Umeyama Sim3; intrinsics from predicted points; long-video Sim3 stitching | `src/eval/tasks.py:11,72`; `infer_track_3d.py:176-216` |
+
+---
+
+## ⚠️ Re-implementer's own choices (paper is silent)
+
+| Item | Code | Note |
+| --- | --- | --- |
+| Stock `nn.MultiheadAttention` + generic **1-D sinusoidal** position embedding | `src/model/encoder.py:122` | Not VideoMAE2's 3-D spatiotemporal pos-embed; the VideoMAE pos-embed is *not* loaded even when block weights are. |
+| `_token_cap` adaptive-avg-pool to cap tokens at 6144 | `src/model/encoder.py:101-110` | Not in the paper; a memory guard. |
+| Decoder width 1280 ≠ encoder 1408, bridged by `memory_proj` Linear | `src/model/d4rt.py:213` | Paper never specifies decoder width. |
+| Anchor-clip / sliding-window stitching for videos longer than clip length | `infer_track_3d.py:89-155` | A plausible reading of appendix B; exact scheme is the author's. |
+
+---
+
+## ❌ Missing, stubbed, or divergent
+
+| Item | Status | Evidence |
+| --- | --- | --- |
+| **Algorithm 1** — occupancy-grid efficient dense all-pixel tracking | **Now implemented in this fork** (was config-only stub) | `dense_track_occupancy_grid` in `infer_track_3d.py` + CLI `infer_dense_track.py`. Pure inference-time scheduler over the frozen model — no retraining. Originally only the string `occupancy_grid_tracking_all_pixels` at `configs/model_effective.yaml:74-76` existed. See "Why it was absent" below. |
+| Full evaluation suite (TAPVid-3D cam/world tracking, Sintel/ScanNet/KITTI/Bonn depth, camera-pose ATE/RPE, point cloud, FPS/throughput, long-video KITTI) | **Not implemented** | Only WorldTrack sparse 3D-tracking exists (`eval_track3d_in_worldtrack.py`). README ToDo confirms full eval is "planned." |
+| Waymo Open dataset (part of the paper's mixture) | **Dropped** | Only referenced as a camera convention in `docs/data_schema.md:161`; not in the training mixture. |
+| SynthVerse (10Mix configs) | **Not released** | Checkpoint Zoo rows marked "Coming." |
+| `λnormal` loss weight | **Divergent: 0.4 vs paper 0.5** | `configs/train_effective.yaml:161` |
+| `reprojection_uv_from_xyz` Huber loss | **Invented extra, off by default** | `src/losses/d4rt_loss.py:161-213` |
+| `lconf_ablation` confidence variant | **Speculative, off by default** | Code itself notes the paper "does not clearly specify a unique formula" (`src/losses/d4rt_loss.py:70-78`). |
+
+---
+
+## Why Algorithm 1 was absent despite being the paper's efficiency centerpiece
+
+> **Update:** it is now implemented here as `dense_track_occupancy_grid`
+> (`infer_track_3d.py`) with the `infer_dense_track.py` CLI. The notes below
+> explain why the original release shipped without it.
+
+Algorithm 1 is a **pure inference-time accelerator for the dense, all-pixel
+tracking task** — orthogonal to correctness and to every metric this repo
+reports:
+
+1. **It changes speed, not output.** It maintains an occupancy grid, seeds new
+   tracks only from un-visited pixels, and marks pixels a track passes through as
+   visited. Naive full-grid querying yields the *same* trajectories; Alg. 1 only
+   skips re-tracking already-covered pixels (paper frames it as a 5–15× adaptive
+   speedup, not an accuracy feature).
+2. **Training never needs it** — training uses sparse queries
+   (`queries_per_clip: 4096`, `configs/train_effective.yaml:129`), not all pixels.
+3. **The only released eval never needs it** — WorldTrack evaluates sparse
+   first-frame-visible queries (`eval_track3d_in_worldtrack.py:503-521`), an
+   already-small fixed query set.
+4. **The dense demo uses naive querying** — a fixed `_grid_query_points` grid
+   (`infer_track_3d.py:68-86`), no occupancy grid.
+
+So the dense all-pixel path that would benefit from Alg. 1 simply isn't wired up
+in the public release; the config entry marks intended behavior only.
+
+---
+
+## Practical implications
+
+- **To run/evaluate:** download a checkpoint from HuggingFace
+  (`Lijiaxin0111/OpenD4RT`, two real ~14 GB `opend4rt.ckpt` files) and use the
+  WorldTrack eval / `infer_track_3d.py`. No training required. Checkpoints are
+  git-ignored (`/checkpoints/**/*.ckpt`); only `model.yaml` ships in-repo.
+- **Reported numbers are self-reported** for this re-implementation, not the
+  official D4RT, and only on the WorldTrack subset.
+- **To train/reproduce:** you additionally need the VideoMAE2 ViT-g init
+  (`vit_g_hybrid_pt_1200e.pth` via `VIDEOMAE2_CKPT`) and all 9 raw datasets.
+- Dense, high-throughput all-pixel 4D reconstruction (the Alg. 1 use case) is not
+  available out of the box.

--- a/infer_dense_track.py
+++ b/infer_dense_track.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Run Algorithm 1 (occupancy-grid dense tracking) on a single video/clip.
+
+This exercises ``dense_track_occupancy_grid`` from ``infer_track_3d``: it encodes
+the clip once and adaptively seeds tracks only from grid cells not yet covered by
+an existing track, returning a unified-frame dense 3D point set plus a speedup
+report versus naive all-cell querying. No retraining is involved; it is a pure
+inference-time scheduler over the frozen model.
+
+Example:
+    EXP=checkpoints/OpenD4RT_32CLIP_9Dataset_NoAUG
+    python infer_dense_track.py \
+        --model-config "$EXP/model.yaml" \
+        --ckpt-path "$EXP/opend4rt.ckpt" \
+        --input data/worldtrack_release/pstudio_mini/softball_25.npz \
+        --grid 48 --seed-batch 512 --output-dir tmp/dense_track
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from eval_track3d_in_worldtrack import load_worldtrack_sequence
+from infer_track_3d import (
+    _load_video_rgb,
+    _resize_video,
+    _resolve_device,
+    _unwrap_state_dict,
+    dense_track_occupancy_grid,
+)
+from src.core import build_logger, load_checkpoint, load_yaml_config, seed_everything
+from src.eval.tasks import _model_clip_frames
+from src.model import build_model
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Occupancy-grid dense 3D tracking (Algorithm 1).")
+    parser.add_argument("--model-config", required=True, help="Model config yaml.")
+    parser.add_argument("--ckpt-path", required=True, help="Checkpoint path.")
+    parser.add_argument("--input", required=True, help="WorldTrack .npz or a video file.")
+    parser.add_argument("--output-dir", default="tmp/dense_track")
+    parser.add_argument("--device", default="auto", choices=("auto", "cuda", "cpu"))
+    parser.add_argument("--num-frames", type=int, default=0, help="Frames to use; <=0 means the model clip length.")
+    parser.add_argument("--grid", type=int, default=48, help="Occupancy-grid / seeding resolution (grid x grid).")
+    parser.add_argument("--seed-batch", type=int, default=512, help="Source points seeded per iteration (batch B).")
+    parser.add_argument("--query-chunk-size", type=int, default=4096)
+    parser.add_argument("--mark-radius", type=int, default=1, help="Neighborhood radius when marking visited cells.")
+    parser.add_argument("--visible-thresh", type=float, default=0.5)
+    parser.add_argument("--reference-frame", type=int, default=0, help="Camera frame the 3D tracks are expressed in.")
+    parser.add_argument("--max-tracks", type=int, default=0, help="Safety cap on emitted tracks; <=0 disables.")
+    parser.add_argument(
+        "--source-frames",
+        default="",
+        help="Comma-separated frames allowed to seed sources. Empty means all frames.",
+    )
+    return parser.parse_args()
+
+
+def _load_video(input_path: Path, num_frames_cap: int) -> np.ndarray:
+    if input_path.suffix.lower() == ".npz":
+        sample = load_worldtrack_sequence(input_path, num_frames=num_frames_cap if num_frames_cap > 0 else 1_000_000)
+        return np.asarray(sample["video_rgb"])
+    video_rgb, _ = _load_video_rgb(input_path, max_frames=num_frames_cap if num_frames_cap > 0 else 0)
+    return np.asarray(video_rgb)
+
+
+def main() -> int:
+    args = parse_args()
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    logger = build_logger("infer_dense_track", output_dir)
+
+    cfg = load_yaml_config(args.model_config)
+    seed_everything(int(cfg.get_path("experiment.seed", 42)), deterministic=True)
+
+    ckpt_path = Path(args.ckpt_path)
+    if not ckpt_path.exists():
+        raise FileNotFoundError(f"Checkpoint not found: {ckpt_path}")
+
+    model = build_model(cfg["model"]).eval()
+    payload = load_checkpoint(ckpt_path, map_location="cpu")
+    state_dict = _unwrap_state_dict(payload)
+    if not state_dict:
+        raise RuntimeError(f"No model weights found in checkpoint: {ckpt_path}")
+    load_result = model.load_state_dict(state_dict, strict=False)
+    logger.info(
+        "Loaded checkpoint %s (missing=%d unexpected=%d)",
+        ckpt_path,
+        len(load_result.missing_keys),
+        len(load_result.unexpected_keys),
+    )
+    device = _resolve_device(args.device)
+    model.to(device).eval()
+
+    clip_frames = _model_clip_frames(model)
+    input_path = Path(args.input)
+    if not input_path.exists():
+        raise FileNotFoundError(f"Input not found: {input_path}")
+
+    video_rgb = _load_video(input_path, num_frames_cap=args.num_frames)
+    target_frames = clip_frames if args.num_frames <= 0 else min(int(args.num_frames), clip_frames)
+    if video_rgb.shape[0] > target_frames:
+        logger.info("Trimming %d frames to clip length %d", int(video_rgb.shape[0]), target_frames)
+        video_rgb = video_rgb[:target_frames]
+
+    image_size = cfg.get_path("model.input.image_size", [256, 256])
+    video_model_rgb = _resize_video(video_rgb, image_hw=(int(image_size[0]), int(image_size[1])))
+
+    source_frames = None
+    if str(args.source_frames).strip():
+        source_frames = [int(v) for v in str(args.source_frames).split(",") if v.strip()]
+
+    result = dense_track_occupancy_grid(
+        model=model,
+        video_model_rgb=video_model_rgb,
+        grid_hw=(int(args.grid), int(args.grid)),
+        seed_batch_size=int(args.seed_batch),
+        query_chunk_size=int(args.query_chunk_size),
+        source_frames=source_frames,
+        visible_thresh=float(args.visible_thresh),
+        mark_radius=int(args.mark_radius),
+        max_tracks=int(args.max_tracks),
+        reference_frame=int(args.reference_frame),
+    )
+    diagnostics = result["diagnostics"]
+
+    tracks_path = output_dir / f"{input_path.stem}_dense_tracks.npz"
+    np.savez_compressed(
+        tracks_path,
+        tracks_xyz_ref=result["tracks_xyz_ref"],
+        tracks_uv_norm=result["tracks_uv_norm"],
+        tracks_visibility=result["tracks_visibility"],
+        tracks_confidence=result["tracks_confidence"],
+        source_uv_norm=result["source_uv_norm"],
+        source_t_src=result["source_t_src"],
+        reference_frame=result["reference_frame"],
+        clip_frames=result["clip_frames"],
+    )
+    diag_path = output_dir / f"{input_path.stem}_dense_tracks_diagnostics.json"
+    diag_path.write_text(json.dumps(diagnostics, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    logger.info(
+        "Dense tracking done: tracks=%d iters=%d grid=%dx%d frames=%d ref=%d",
+        diagnostics["num_tracks"],
+        diagnostics["num_iterations"],
+        diagnostics["grid_hw"][0],
+        diagnostics["grid_hw"][1],
+        diagnostics["num_frames"],
+        diagnostics["reference_frame"],
+    )
+    logger.info(
+        "Adaptive speedup vs naive all-cell seeding: %.2fx (tracks %d vs %d cells); "
+        "decoder-query speedup: %.2fx; grid coverage: %.1f%%",
+        diagnostics["seed_speedup_ratio"],
+        diagnostics["num_tracks"],
+        diagnostics["naive_seed_cells"],
+        diagnostics["query_speedup_ratio"],
+        100.0 * diagnostics["occupancy_filled_ratio"],
+    )
+    print(json.dumps(diagnostics, ensure_ascii=False, indent=2))
+    logger.info("Saved tracks to %s", tracks_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/infer_track_3d.py
+++ b/infer_track_3d.py
@@ -500,3 +500,263 @@ def _infer_tracks(
         "clip_frames": np.asarray(clip_frames, dtype=np.int32),
         "stitch_diagnostics": stitch_diagnostics,
     }
+
+
+def _decode_tracks_for_sources(
+    *,
+    model: torch.nn.Module,
+    video_clip: torch.Tensor,
+    aspect_ratio: torch.Tensor | None,
+    memory: torch.Tensor | None,
+    source_uv_norm: np.ndarray,
+    source_t_src: np.ndarray,
+    num_frames: int,
+    reference_frame: int,
+    query_chunk_size: int,
+) -> dict[str, np.ndarray]:
+    """Decode full per-frame tracks for a batch of source points.
+
+    For each source ``(u, v, t_src)`` this issues one query per target frame
+    ``k`` with ``t_tgt=k`` and ``t_cam=reference_frame``, i.e. line 7-8 of
+    Algorithm 1, reusing the same decoder path as the rest of inference.
+    Returns arrays shaped ``[num_sources, num_frames, ...]``.
+    """
+    num_sources = int(source_uv_norm.shape[0])
+    if num_sources == 0:
+        return {
+            "xyz_3d": np.zeros((0, num_frames, 3), dtype=np.float32),
+            "uv_2d": np.zeros((0, num_frames, 2), dtype=np.float32),
+            "visibility": np.zeros((0, num_frames), dtype=np.float32),
+            "confidence": np.zeros((0, num_frames), dtype=np.float32),
+        }
+
+    repeated_uv = np.repeat(source_uv_norm.astype(np.float32), num_frames, axis=0)
+    t_src = np.repeat(source_t_src.astype(np.int64), num_frames)
+    t_tgt = np.tile(np.arange(num_frames, dtype=np.int64), num_sources)
+    t_cam = np.full_like(t_tgt, int(reference_frame))
+    query = _build_query_for_targets(
+        query_uv_norm=repeated_uv,
+        t_src=t_src,
+        t_tgt=t_tgt,
+        t_cam=t_cam,
+        device=video_clip.device,
+    )
+    pred = _run_model_for_queries(
+        model=model,
+        video_b=video_clip,
+        aspect_b=aspect_ratio,
+        query=query,
+        chunk_size=max(1, int(query_chunk_size)),
+        memory_b=memory,
+    )
+
+    out: dict[str, np.ndarray] = {}
+    for key, value in pred.items():
+        arr = value.numpy()
+        if arr.ndim == 1:
+            out[key] = arr.reshape(num_sources, num_frames)
+        else:
+            out[key] = arr.reshape(num_sources, num_frames, *arr.shape[1:])
+    return out
+
+
+def dense_track_occupancy_grid(
+    *,
+    model: torch.nn.Module,
+    video_model_rgb: np.ndarray,
+    grid_hw: tuple[int, int] = (48, 48),
+    seed_batch_size: int = 512,
+    query_chunk_size: int = 4096,
+    source_frames: list[int] | None = None,
+    visible_thresh: float = 0.5,
+    mark_radius: int = 1,
+    max_tracks: int = 0,
+    reference_frame: int = 0,
+) -> dict[str, Any]:
+    """Algorithm 1: efficient dense tracking of all pixels via an occupancy grid.
+
+    This is an inference-time scheduler around the *frozen* model. The video is
+    encoded once into the Global Scene Representation; new tracks are only seeded
+    from grid cells not yet covered by an existing track, exploiting the
+    spatio-temporal redundancy described in the paper. No weights are modified and
+    no retraining is required.
+
+    Processes a single encoded clip, so ``num_frames`` must not exceed the model
+    clip length. The decoded 3D tracks are expressed in ``reference_frame``'s
+    camera, giving a unified-frame dense point set.
+    """
+    device = next(model.parameters()).device
+    num_frames = int(video_model_rgb.shape[0])
+    clip_frames = _model_clip_frames(model)
+    if num_frames > clip_frames:
+        raise ValueError(
+            f"dense_track_occupancy_grid processes one encoded clip; got "
+            f"num_frames={num_frames} > clip_frames={clip_frames}. Trim the clip "
+            f"or use the sliding-window path in _infer_tracks for longer videos."
+        )
+
+    gh, gw = int(grid_hw[0]), int(grid_hw[1])
+    if gh <= 0 or gw <= 0:
+        raise ValueError(f"grid_hw must be positive, got {grid_hw}")
+    reference_frame = int(np.clip(int(reference_frame), 0, max(0, num_frames - 1)))
+
+    if source_frames is None:
+        allowed_frames = list(range(num_frames))
+    else:
+        allowed_frames = sorted(
+            {int(np.clip(int(f), 0, max(0, num_frames - 1))) for f in source_frames}
+        )
+
+    aspect_value = np.asarray(
+        [[float(video_model_rgb.shape[2]) / float(max(1, video_model_rgb.shape[1]))]],
+        dtype=np.float32,
+    )
+    aspect_tensor = torch.from_numpy(aspect_value).to(device=device, dtype=torch.float32)
+    video_tensor = (
+        torch.from_numpy(np.ascontiguousarray(video_model_rgb))
+        .to(device=device, dtype=torch.float32)
+        .permute(0, 3, 1, 2)
+        .unsqueeze(0)
+        / 255.0
+    )
+
+    occupancy = np.zeros((num_frames, gh, gw), dtype=bool)
+    seedable = np.zeros((num_frames, gh, gw), dtype=bool)
+    for frame_idx in allowed_frames:
+        seedable[frame_idx] = True
+
+    cell_u = (np.arange(gw, dtype=np.float32) + 0.5) / float(gw)
+    cell_v = (np.arange(gh, dtype=np.float32) + 0.5) / float(gh)
+
+    tracks_xyz: list[np.ndarray] = []
+    tracks_uv: list[np.ndarray] = []
+    tracks_vis: list[np.ndarray] = []
+    tracks_conf: list[np.ndarray] = []
+    source_uv_list: list[np.ndarray] = []
+    source_t_list: list[np.ndarray] = []
+
+    num_iterations = 0
+    decoder_queries_used = 0
+
+    with torch.no_grad():
+        memory = _encode_model_memory(model=model, video_b=video_tensor, aspect_b=aspect_tensor)
+        while True:
+            unvisited = seedable & (~occupancy)
+            cells = np.argwhere(unvisited)  # rows are (t, gy, gx), frame-ascending
+            if cells.shape[0] == 0:
+                break
+            batch_limit = int(seed_batch_size)
+            if max_tracks > 0:
+                remaining = int(max_tracks) - sum(int(s.shape[0]) for s in source_t_list)
+                if remaining <= 0:
+                    break
+                batch_limit = min(batch_limit, remaining)
+            batch_cells = cells[:batch_limit]
+
+            src_t = batch_cells[:, 0].astype(np.int64)
+            src_gy = batch_cells[:, 1].astype(np.int64)
+            src_gx = batch_cells[:, 2].astype(np.int64)
+            # Mark seeded source cells immediately so they are never re-seeded.
+            occupancy[src_t, src_gy, src_gx] = True
+
+            src_uv = np.stack([cell_u[src_gx], cell_v[src_gy]], axis=-1).astype(np.float32)
+            decoded = _decode_tracks_for_sources(
+                model=model,
+                video_clip=video_tensor,
+                aspect_ratio=aspect_tensor,
+                memory=memory,
+                source_uv_norm=src_uv,
+                source_t_src=src_t,
+                num_frames=num_frames,
+                reference_frame=reference_frame,
+                query_chunk_size=query_chunk_size,
+            )
+            num_iterations += 1
+            decoder_queries_used += int(src_uv.shape[0]) * num_frames
+
+            xyz = decoded["xyz_3d"].astype(np.float32)  # [S, T, 3]
+            uv = decoded["uv_2d"].astype(np.float32)  # [S, T, 2]
+            vis_logits = decoded["visibility"].astype(np.float32)  # [S, T]
+            conf = decoded.get("confidence")
+            conf = (
+                np.full((xyz.shape[0], num_frames), np.nan, dtype=np.float32)
+                if conf is None
+                else conf.astype(np.float32)
+            )
+            vis = (1.0 / (1.0 + np.exp(-vis_logits))) > float(visible_thresh)
+
+            # Visible(P): mark every grid cell a track visibly passes through.
+            uv_clamped = np.clip(uv, 0.0, 1.0)
+            gx_land = np.clip((uv_clamped[..., 0] * gw).astype(np.int64), 0, gw - 1)
+            gy_land = np.clip((uv_clamped[..., 1] * gh).astype(np.int64), 0, gh - 1)
+            frame_ids = np.broadcast_to(np.arange(num_frames, dtype=np.int64)[None, :], gx_land.shape)
+            vis_flat = vis.reshape(-1)
+            t_flat = frame_ids.reshape(-1)[vis_flat]
+            gx_flat = gx_land.reshape(-1)[vis_flat]
+            gy_flat = gy_land.reshape(-1)[vis_flat]
+            radius = int(mark_radius)
+            if radius <= 0:
+                occupancy[t_flat, gy_flat, gx_flat] = True
+            else:
+                for dy in range(-radius, radius + 1):
+                    yy = np.clip(gy_flat + dy, 0, gh - 1)
+                    for dx in range(-radius, radius + 1):
+                        xx = np.clip(gx_flat + dx, 0, gw - 1)
+                        occupancy[t_flat, yy, xx] = True
+
+            tracks_xyz.append(xyz)
+            tracks_uv.append(uv)
+            tracks_vis.append(vis)
+            tracks_conf.append(conf)
+            source_uv_list.append(src_uv)
+            source_t_list.append(src_t)
+
+    if tracks_xyz:
+        out_xyz = np.concatenate(tracks_xyz, axis=0)
+        out_uv = np.concatenate(tracks_uv, axis=0)
+        out_vis = np.concatenate(tracks_vis, axis=0)
+        out_conf = np.concatenate(tracks_conf, axis=0)
+        out_src_uv = np.concatenate(source_uv_list, axis=0)
+        out_src_t = np.concatenate(source_t_list, axis=0)
+    else:
+        out_xyz = np.zeros((0, num_frames, 3), dtype=np.float32)
+        out_uv = np.zeros((0, num_frames, 2), dtype=np.float32)
+        out_vis = np.zeros((0, num_frames), dtype=bool)
+        out_conf = np.zeros((0, num_frames), dtype=np.float32)
+        out_src_uv = np.zeros((0, 2), dtype=np.float32)
+        out_src_t = np.zeros((0,), dtype=np.int64)
+
+    num_tracks = int(out_xyz.shape[0])
+    naive_seed_cells = int(len(allowed_frames) * gh * gw)
+    naive_decoder_queries = int(naive_seed_cells * num_frames)
+    diagnostics: dict[str, Any] = {
+        "num_tracks": num_tracks,
+        "num_iterations": int(num_iterations),
+        "grid_hw": [gh, gw],
+        "num_frames": int(num_frames),
+        "clip_frames": int(clip_frames),
+        "reference_frame": int(reference_frame),
+        "source_frames": [int(f) for f in allowed_frames],
+        "mark_radius": int(mark_radius),
+        "visible_thresh": float(visible_thresh),
+        "naive_seed_cells": naive_seed_cells,
+        "decoder_queries_used": int(decoder_queries_used),
+        "decoder_queries_naive": naive_decoder_queries,
+        "seed_speedup_ratio": float(naive_seed_cells / max(1, num_tracks)),
+        "query_speedup_ratio": float(naive_decoder_queries / max(1, decoder_queries_used)),
+        "occupancy_filled_ratio": (
+            float(occupancy[allowed_frames].mean()) if allowed_frames else 0.0
+        ),
+    }
+
+    return {
+        "tracks_xyz_ref": out_xyz,
+        "tracks_uv_norm": out_uv,
+        "tracks_visibility": out_vis,
+        "tracks_confidence": out_conf,
+        "source_uv_norm": out_src_uv,
+        "source_t_src": out_src_t,
+        "reference_frame": np.asarray(reference_frame, dtype=np.int32),
+        "clip_frames": np.asarray(clip_frames, dtype=np.int32),
+        "diagnostics": diagnostics,
+    }

--- a/infer_track_3d.py
+++ b/infer_track_3d.py
@@ -646,6 +646,8 @@ def dense_track_occupancy_grid(
             if cells.shape[0] == 0:
                 break
             batch_limit = int(seed_batch_size)
+            if batch_limit <= 0:
+                raise ValueError(f"seed_batch_size must be positive, got {seed_batch_size}")
             if max_tracks > 0:
                 remaining = int(max_tracks) - sum(int(s.shape[0]) for s in source_t_list)
                 if remaining <= 0:


### PR DESCRIPTION
Summary

  Implements D4RT's Algorithm 1 (occupancy-grid efficient dense all-pixel tracking) as an inference-time scheduler over
  the frozen model, plus a CLI to run it.

  Motivation / Context

  The paper's headline efficiency trick existed only as a config string (occupancy_grid_tracking_all_pixels in
  configs/model_effective.yaml:74-76) with no implementation. It's a pure inference-time scheduler — it exploits
  spatio-temporal redundancy by only seeding tracks from pixels not yet covered by an existing track — so it needs no 
  retraining or weight changes. This wires up the dense-reconstruction path the repo was missing.

  Changes Made

  - infer_track_3d.py: add dense_track_occupancy_grid(...) — encodes the clip once (F = E(V)), then iteratively seeds
  un-visited grid cells, decodes full per-frame tracks, and marks visibly-covered cells visited (paper Alg. 1, lines
  1–13). Reuses the existing _encode_model_memory / _run_model_for_queries / _build_query_for_targets query path.
  - infer_track_3d.py: add _decode_tracks_for_sources(...) helper.
  - infer_dense_track.py: new CLI — loads a checkpoint, takes a WorldTrack .npz or video file, writes *_dense_tracks.npz
  + diagnostics JSON, prints the speedup.
  - docs/paper_vs_code_gap.md: paper-vs-code gap analysis; marks Alg. 1 as now implemented.

  How to Test

  EXP=checkpoints/OpenD4RT_32CLIP_9Dataset_NoAUG
  python infer_dense_track.py \
    --model-config "$EXP/model.yaml" --ckpt-path "$EXP/opend4rt.ckpt" \
    --input data/worldtrack_release/pstudio_mini/softball_25.npz \
    --grid 48 --seed-batch 512 --mark-radius 1 --output-dir tmp/dense_track
  Logic-only smoke test (mock model, no checkpoint needed) verified: correct shapes, clean termination, clip-length
  guard, and the expected adaptive speedup.

  Results
  
  Mock-model smoke test (grid 8×8, 4 frames): 64 tracks vs 256 naive cells → 4× seed + decoder-query speedup,
  occupancy_filled_ratio = 1.0. Real-checkpoint speedup is content-dependent (paper reports 5–15×); output is the same
  per-track quality as naive querying.
  
  Notes / Limitations

  - Within-clip only: processes one encoded clip (raises if num_frames > clip_frames). Long videos need composing with
  the existing anchor-clip/Sim3 stitching — not wired here.
  - It's the redundancy approximation by design: pixels covered by a neighbor's track don't get an independent trajectory
  (that's the source of the speedup).
  - 3D tracks are returned in reference_frame's camera (unified frame for point clouds); occupancy marking uses the uv_2d
  + visibility heads.
  - Not yet validated against the 14 GB checkpoint (no GPU/download in this session); the model-call path reuses
  already-tested helpers.

  Related Work / References
  
  - Paper: Efficiently Reconstructing Dynamic Scenes One D4RT at a Time — Algorithm 1 (docs/D4RT_paper.pdf, p.3)
  - Checkpoints: Lijiaxin0111/OpenD4RT (https://huggingface.co/Lijiaxin0111/OpenD4RT)
  - See docs/paper_vs_code_gap.md
