### PR TITLE
fix: use native aspect ratio in evluation implementation

### DIFF
--- a/eval_track3d_in_worldtrack.py
+++ b/eval_track3d_in_worldtrack.py
@@ -523,6 +523,7 @@ def main() -> int:
             pred_payload = _infer_tracks(
                 model=model,
                 video_model_rgb=video_model_rgb,
+                native_aspect_ratio=float(original_w) / float(max(original_h, 1)),
                 query_uv_norm=query_uv_norm,
                 query_chunk_size=int(args.query_chunk_size),
             )

--- a/infer_track_3d.py
+++ b/infer_track_3d.py
@@ -373,6 +373,7 @@ def _infer_tracks(
     *,
     model: torch.nn.Module,
     video_model_rgb: np.ndarray,
+    native_aspect_ratio: float,    
     query_uv_norm: np.ndarray,
     query_chunk_size: int,
     query_src_indices_global: np.ndarray | None = None,
@@ -384,10 +385,7 @@ def _infer_tracks(
     num_frames = int(video_model_rgb.shape[0])
     num_queries = int(query_uv_norm.shape[0])
     clip_frames = _model_clip_frames(model)
-    aspect_value = np.asarray(
-        [[float(video_model_rgb.shape[2]) / float(max(1, video_model_rgb.shape[1]))]],
-        dtype=np.float32,
-    )
+    aspect_value = np.asarray([[native_aspect_ratio]], dtype=np.float32)
     aspect_tensor = torch.from_numpy(aspect_value).to(device=device, dtype=torch.float32)
 
     tracks_xyz_local = np.full((num_queries, num_frames, 3), np.nan, dtype=np.float32)

--- a/vis/build_like_demo.py
+++ b/vis/build_like_demo.py
@@ -829,6 +829,7 @@ def _infer_point_cloud_ref0(
     *,
     model: torch.nn.Module,
     video_model_rgb: np.ndarray,
+    native_aspect_ratio: float,
     point_query_uv_norm: np.ndarray,
     query_chunk_size: int,
     umeyama_slide_window: bool,
@@ -837,7 +838,7 @@ def _infer_point_cloud_ref0(
     num_frames = int(video_model_rgb.shape[0])
     num_points = int(point_query_uv_norm.shape[0])
     clip_frames = _model_clip_frames(model)
-    aspect_value = np.asarray([[float(video_model_rgb.shape[2]) / float(max(1, video_model_rgb.shape[1]))]], dtype=np.float32)
+    aspect_value = np.asarray([[native_aspect_ratio]], dtype=np.float32)
     aspect_tensor = torch.from_numpy(aspect_value).to(device=device, dtype=torch.float32)
     video_tensor = torch.from_numpy(video_model_rgb).to(device=device, dtype=torch.float32).permute(0, 3, 1, 2).unsqueeze(0) / 255.0
 
@@ -1064,8 +1065,7 @@ def _predict_camera_branches(
     device = next(model.parameters()).device
     num_frames = int(video_model_rgb.shape[0])
     clip_frames = _model_clip_frames(model)
-    hm, wm = int(video_model_rgb.shape[1]), int(video_model_rgb.shape[2])
-    aspect_value = np.asarray([[float(wm) / float(max(1, hm))]], dtype=np.float32)
+    aspect_value = np.asarray([[float(image_hw[1]) / float(max(1, image_hw[0]))]], dtype=np.float32)
     aspect_tensor = torch.from_numpy(aspect_value).to(device=device, dtype=torch.float32)
     video_tensor = torch.from_numpy(video_model_rgb).to(device=device, dtype=torch.float32).permute(0, 3, 1, 2).unsqueeze(0) / 255.0
     coarse_uv = _make_normalized_uv_grid(camera_grid_size)
@@ -1296,12 +1296,7 @@ def _export_demo_data(
     num_frames = int(video_model_rgb.shape[0])
     clip_frames = _model_clip_frames(model)
     h0, w0 = int(video_rgb.shape[1]), int(video_rgb.shape[2])
-    hm, wm = int(video_model_rgb.shape[1]), int(video_model_rgb.shape[2])
-
-    aspect_value = np.asarray([[float(wm) / float(max(1, hm))]], dtype=np.float32)
-    aspect_tensor = torch.from_numpy(aspect_value).to(device=device, dtype=torch.float32)
-    video_tensor = torch.from_numpy(video_model_rgb).to(device=device, dtype=torch.float32).permute(0, 3, 1, 2).unsqueeze(0) / 255.0
-
+    aspect_value = float(w0) / float(max(1, h0))
     point_query_uv_norm = point_query_uv_px.copy()
     point_query_uv_norm[:, 0] /= float(max(w0 - 1, 1))
     point_query_uv_norm[:, 1] /= float(max(h0 - 1, 1))
@@ -1316,6 +1311,7 @@ def _export_demo_data(
     points_xyz_ref0, points_vis, points_conf, _ = _infer_point_cloud_ref0(
         model=model,
         video_model_rgb=video_model_rgb,
+        native_aspect_ratio=aspect_value,
         point_query_uv_norm=point_query_uv_norm,
         query_chunk_size=point_query_chunk_size,
         umeyama_slide_window=bool(umeyama_slide_window),
@@ -1394,6 +1390,7 @@ def _export_demo_data(
     track_payload = _infer_tracks(
         model=model,
         video_model_rgb=video_model_rgb,
+        native_aspect_ratio=aspect_value,
         query_uv_norm=track_query_uv_norm.astype(np.float32),
         query_chunk_size=track_query_chunk_size,
         query_src_indices_global=track_query_t_src,


### PR DESCRIPTION
Related to #17 .

infer_track_3d.py computed the aspect_ratio token from the resized model input shape (video_model_rgb.shape[2] / shape[1]), which is always model_w / model_h — a constant regardless of the original video's dimensions. For a square model input (256×256), this is always 1.0.

However, during training, all datasets feed the aspect ratio as the native content dimensions before any resizing (e.g. src_w / src_h from the original image file or TFDS metadata). When a non-square video is non-uniformly squashed into the model's fixed input, this token tells the model the true geometric distortion that occurred.

This train/inference mismatch affects prediction accuracy for non-square input videos. The use_aspect_ratio_token is enabled in all published model configs (configs/model_effective.yaml and both checkpoint model.yaml files), so the bug is active.
